### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # `ssh-agent` GitHub Action
 
 This action

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
         description: 'git command'
         required: false
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'dist/index.js'
     post: 'dist/cleanup.js'
     post-if: 'always()'

--- a/dist/index.js
+++ b/dist/index.js
@@ -11660,19 +11660,49 @@ const { homePath, sshAgentCmd, sshAddCmd, gitCmd } = __nccwpck_require__(6644);
 
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  let repoPrivate
 
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+    repoPrivate = eventData && eventData.repository && eventData.repository.private
+  }
+
+  const upstream = 'webfactory/ssh-agent'
+  const action = process.env.GITHUB_ACTION_REPOSITORY
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
+
+  core.info('')
+  core.info('\u001b[1;36mStepSecurity Maintained Action\u001b[0m')
+  core.info(`Secure drop-in replacement for ${upstream}`)
+  if (repoPrivate === false)
+    core.info('\u001b[32m\u2713 Free for public repositories\u001b[0m')
+  core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`)
+  core.info('')
+
+  if (repoPrivate === false) return
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const body = {action: action || ''}
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl
   try {
-    await lib_axios.get(API_URL, { timeout: 3000 })
+    await lib_axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      {timeout: 3000}
+    )
   } catch (error) {
     if (error.response && error.response.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`
+      )
+      core.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`
       )
       process.exit(1)
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.')
     }
+    core.info('Timeout or API not reachable. Continuing to next step.')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -6,19 +6,49 @@ const { homePath, sshAgentCmd, sshAddCmd, gitCmd } = require('./paths.js');
 import axios from 'axios'
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  let repoPrivate
 
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+    repoPrivate = eventData && eventData.repository && eventData.repository.private
+  }
+
+  const upstream = 'webfactory/ssh-agent'
+  const action = process.env.GITHUB_ACTION_REPOSITORY
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
+
+  core.info('')
+  core.info('\u001b[1;36mStepSecurity Maintained Action\u001b[0m')
+  core.info(`Secure drop-in replacement for ${upstream}`)
+  if (repoPrivate === false)
+    core.info('\u001b[32m\u2713 Free for public repositories\u001b[0m')
+  core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`)
+  core.info('')
+
+  if (repoPrivate === false) return
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const body = {action: action || ''}
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl
   try {
-    await axios.get(API_URL, { timeout: 3000 })
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      {timeout: 3000}
+    )
   } catch (error) {
     if (error.response && error.response.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
+        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`
+      )
+      core.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`
       )
       process.exit(1)
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.')
     }
+    core.info('Timeout or API not reachable. Continuing to next step.')
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (action.yml)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, rebuilt dist/
- **Docker/Shell actions**: replaced entrypoint.sh subscription block
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260325T061937Z